### PR TITLE
[LMS-360] SubmissionDateTime is nullable

### DIFF
--- a/extension/EdFi.Ods.Extensions.LMSX/Artifacts/Metadata/ApiModel-EXTENSION.json
+++ b/extension/EdFi.Ods.Extensions.LMSX/Artifacts/Metadata/ApiModel-EXTENSION.json
@@ -466,7 +466,7 @@
             "maxLength": 0,
             "precision": 0,
             "scale": 0,
-            "isNullable": false
+            "isNullable": true
           },
           "description": "The date and time of the assignment submission.",
           "isIdentifying": false,

--- a/extension/EdFi.Ods.Extensions.LMSX/Artifacts/MsSql/Structure/Ods/0020-EXTENSION-LMSX-Tables.sql
+++ b/extension/EdFi.Ods.Extensions.LMSX/Artifacts/MsSql/Structure/Ods/0020-EXTENSION-LMSX-Tables.sql
@@ -48,7 +48,7 @@ CREATE TABLE [lmsx].[AssignmentSubmission] (
     [StudentUSI] [INT] NOT NULL,
     [AssignmentIdentifier] [NVARCHAR](255) NOT NULL,
     [SubmissionStatusDescriptorId] [INT] NOT NULL,
-    [SubmissionDateTime] [DATETIME2](7) NOT NULL,
+    [SubmissionDateTime] [DATETIME2](7) NULL,
     [EarnedPoints] [INT] NULL,
     [Grade] [NVARCHAR](20) NULL,
     [Discriminator] [NVARCHAR](128) NULL,

--- a/extension/EdFi.Ods.Extensions.LMSX/Artifacts/PgSql/Structure/Ods/0020-EXTENSION-LMSX-Tables.sql
+++ b/extension/EdFi.Ods.Extensions.LMSX/Artifacts/PgSql/Structure/Ods/0020-EXTENSION-LMSX-Tables.sql
@@ -38,7 +38,7 @@ CREATE TABLE lmsx.AssignmentSubmission (
     StudentUSI INT NOT NULL,
     AssignmentIdentifier VARCHAR(255) NOT NULL,
     SubmissionStatusDescriptorId INT NOT NULL,
-    SubmissionDateTime TIMESTAMP NOT NULL,
+    SubmissionDateTime TIMESTAMP NULL,
     EarnedPoints INT NULL,
     Grade VARCHAR(20) NULL,
     Discriminator VARCHAR(128) NULL,

--- a/extension/EdFi.Ods.Extensions.LMSX/Artifacts/Schemas/EXTENSION-Ed-Fi-Extended-Core.xsd
+++ b/extension/EdFi.Ods.Extensions.LMSX/Artifacts/Schemas/EXTENSION-Ed-Fi-Extended-Core.xsd
@@ -128,7 +128,7 @@
               </xs:appinfo>
             </xs:annotation>
           </xs:element>
-          <xs:element name="SubmissionDateTime" type="xs:dateTime">
+          <xs:element name="SubmissionDateTime" type="xs:dateTime" minOccurs="0">
             <xs:annotation>
               <xs:documentation>The date and time of the assignment submission.</xs:documentation>
             </xs:annotation>

--- a/extension/EdFiLMSMetaEd/DomainEntity/AssignmentSubmission.metaed
+++ b/extension/EdFiLMSMetaEd/DomainEntity/AssignmentSubmission.metaed
@@ -21,7 +21,7 @@ Domain Entity AssignmentSubmission
         is required
     datetime SubmissionDateTime
         documentation "The date and time of the assignment submission."
-        is required
+        is optional
     shared integer Points
         documentation "The points earned for the submission."
         is optional


### PR DESCRIPTION
To test this, simply copy the `extension/EdFi.Ods.Extensions.LMSX` files to `Ed-Fi-ODS-Implementation/Applications/EdFi.Ods.Extensions.LMSX`, add a reference in the Web API project to the LMSX project, and run initdev. Look at the PopulatedTemplate database - is the column nullable in the {{lmsx.AssignmentSubmission}} table?

Then try uploading the new `docs/starter-kit-sample` files into the populated template db, using the LMS-DS-Loader. Before the change that would have failed, with an error about inserting null into a non-nullable field. Now it is accepted.