### PR TITLE
[LMS-371] Get courses directly from /api/v1/courses

### DIFF
--- a/src/canvas-extractor/edfi_canvas_extractor/api/courses.py
+++ b/src/canvas-extractor/edfi_canvas_extractor/api/courses.py
@@ -2,16 +2,16 @@
 # Licensed to the Ed-Fi Alliance under one or more agreements.
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
+
 import logging
 from typing import List
 
 from pandas import DataFrame
 import sqlalchemy
 from opnieuw import retry
-
 from canvasapi import Canvas
-from canvasapi.account import Account
 from canvasapi.course import Course
+
 from edfi_lms_extractor_lib.api.resource_sync import (
     cleanup_after_sync,
     sync_to_db_without_cleanup,
@@ -42,18 +42,11 @@ def request_courses(canvas: Canvas, start_date: str, end_date: str) -> List[Cour
     """
     logger.info("Pulling course data")
 
-    results: List = []
-
-    accounts: List[Account] = canvas.get_accounts()
-    for account in accounts:
-        courses: List[Course] = account.get_courses(
-            state=["available", "completed"],
-            starts_before=end_date,
-            ends_after=start_date,
-        )
-        results.extend(courses)
-
-    return results
+    return canvas.get_courses(
+        state=["available", "completed"],
+        starts_before=end_date,
+        ends_after=start_date,
+    )
 
 
 def courses_synced_as_df(


### PR DESCRIPTION
Remove the dependency on accounts so the course does not get duplicated by having a subaccount set.

I already created the subaccount in the test environment, you can check the steps to reproduce and look at the development subaccount, it has two courses referenced. So, simply run the code and it should be working without any error nor duplicated data.